### PR TITLE
Only require 0.6.12 as a minimum

### DIFF
--- a/contracts/BoringOwnable.sol
+++ b/contracts/BoringOwnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity >= 0.6.12 <= 0.8.12;
 
 // Source: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol + Claimable.sol
 // Simplified by BoringCrypto


### PR DESCRIPTION
This library has been tested for versions larger than 0.6.12
no changes in subsequent compiler versions that would break this library